### PR TITLE
fix: rename overlay CSS class

### DIFF
--- a/sphinx_contributor_listing/_static/contributors.css
+++ b/sphinx_contributor_listing/_static/contributors.css
@@ -32,7 +32,7 @@
   display: inline-block;
 }
 
-#overlay {
+#all-contributors-overlay {
   position: fixed;
   display: none;
   width: 100%;

--- a/sphinx_contributor_listing/_static/contributors.js
+++ b/sphinx_contributor_listing/_static/contributors.js
@@ -1,12 +1,12 @@
 $(document).ready(function() {
     $(document).on("click", function () {
         $(".all-contributors").hide();
-        $("#overlay").hide();
+        $("#all-contributors-overlay").hide();
     });
 
     $('.display-contributors').click(function(event) {
         $('.all-contributors').toggle();
-        $("#overlay").toggle();
+        $("#all-contributors-overlay").toggle();
         event.stopPropagation();
     });
 })


### PR DESCRIPTION
`overlay` is a very common term that could appear in HTML. It's currently colliding with the ID for a section called _Overlay_ in the Craft Parts documentation. By adding some more specifiers to the class, the CSS won't unintentionally affect other elements on the page.

---
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
