### PR TITLE
docs: add templating example to README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,5 +24,6 @@ repos:
     rev: "" # Intentionally blank, despite the warning.
     hooks:
       - id: prettier
+        files: ^(.\/?)*\.(yaml|yml|json|json5|css|md)$
         additional_dependencies:
           - prettier@3.4.2

--- a/README.md
+++ b/README.md
@@ -33,15 +33,51 @@ conf.py file to include sphinx-contributor-listing as one of its extensions:
 extensions = [
     "sphinx_contributor_listing"
 ]
-
-# Configuration options
-display_contributors = True  # Enable contributor display
-github_folder = "/docs/"     # Path to documentation folder in repository
-github_url = "https://github.com/your-org/your-repo"  # Base URL for commit links
-
-# Optional: Filter commits by date
-display_contributors_since = "2024-01-01"  # Only show contributors since this date
 ```
+
+Then, in your conf.py file, update `html_context` to include the following values:
+
+```python
+html_context = {
+    # Required
+    display_contributors = True  # Enable contributor display
+    github_url = "https://github.com/your-org/your-repo"  # Base URL for commit links
+    github_folder = "/docs/"     # Path to documentation folder in repository
+
+    # Optional: Filter commits by date
+    display_contributors_since = "2024-01-01"  # Only show contributors since this date
+}
+```
+
+To list the contributors on each page, update your project's template to include the
+`get_contributors_for_file` function. To display contributors in the page footer, you'd
+update the `footer.html` file to include something akin to:
+
+```html
+  <div>
+    {% if display_contributors and pagename and page_source_suffix %}
+        {% set contributors = get_contributors_for_file(pagename, page_source_suffix) %}
+        {% if contributors %}
+          {% if contributors | length > 1 %}
+              <a class="display-contributors">Thanks to the {{ contributors | length }} contributors!</a>
+          {% else %}
+              <a class="display-contributors">Thanks to our contributor!</a>
+          {% endif %}
+          <div id="overlay"></div>
+          <ul class="all-contributors">
+              {% for name, github_url in contributors %}
+                  <li>
+                      <a href="{{ github_url }}" class="contributor">{{ name }}</a>
+                  </li>
+              {% endfor %}
+          </ul>
+       {% endif %}
+   {% endif %}
+  </div>
+```
+
+For more information on templating in Sphinx, refer to
+[Templating](https://www.sphinx-doc.org/en/master/development/html_themes/templating.html).
 
 ## Community and support
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To list the contributors on each page, update your project's template to include
 `get_contributors_for_file` function. To display contributors in the page footer, you'd
 update the `footer.html` file to include something akin to:
 
-```html
+```
   <div>
     {% if display_contributors and pagename and page_source_suffix %}
         {% set contributors = get_contributors_for_file(pagename, page_source_suffix) %}


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

Resolves https://github.com/canonical/sphinx-contributor-listing/issues/17

It was recently brought to my attention that nobody's templates are set up correctly for this extension, even if everything else is in order. The templates in the old README and canonical-sphinx are broken, so it'll be worthwhile to have at least one functional example.

While we're removing this from the Starter Pack in the near future, we should still support this for users of the current version and older.