### PR TITLE
chore: switch to 'repo_folder' context var

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ html_context = {
     # Required
     display_contributors = True  # Enable contributor display
     github_url = "https://github.com/your-org/your-repo"  # Base URL for commit links
-    github_folder = "/docs/"     # Path to documentation folder in repository
+    repo_folder = "/docs/"     # Path to documentation folder in repository
 
     # Optional: Filter commits by date
     display_contributors_since = "2024-01-01"  # Only show contributors since this date

--- a/sphinx_contributor_listing/__init__.py
+++ b/sphinx_contributor_listing/__init__.py
@@ -43,8 +43,8 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     html_context = app.config.html_context
     if html_context.get("github_folder"):
         logger.info(
-            "%s: conf.py: 'github_folder' is deprecated. Using 'repo_folder' instead.",
-            __name__,
+            f"{__name__}: conf.py: 'github_folder' is deprecated. "
+            "Using 'repo_folder' instead.",
             color="yellow",
         )
         if not html_context.get("repo_folder"):

--- a/sphinx_contributor_listing/__init__.py
+++ b/sphinx_contributor_listing/__init__.py
@@ -21,6 +21,7 @@ from sphinx.util.typing import ExtensionMetadata
 
 from sphinx_contributor_listing import common
 from sphinx_contributor_listing.callback import add_contributor_context
+from sphinx.util import logging
 
 
 try:
@@ -36,6 +37,19 @@ except ImportError:  # pragma: no cover
 
 def setup(app: Sphinx) -> ExtensionMetadata:
     """Connect the callback function and add custom CSS and JS."""
+    logger = logging.getLogger(__name__)
+
+    # Backward-compatible context vars
+    html_context = app.config.html_context
+    if html_context.get("github_folder"):
+        logger.info(
+            "%s: conf.py: 'github_folder' is deprecated. Using 'repo_folder' instead.",
+            __name__,
+            color="yellow",
+        )
+        if not html_context.get("repo_folder"):
+            html_context["repo_folder"] = html_context["github_folder"]
+
     app.connect("html-page-context", add_contributor_context)  # type: ignore[reportUnknownMemberType]
     common.add_css(app, "contributors.css")
     common.add_js(app, "contributors.js")

--- a/sphinx_contributor_listing/__init__.py
+++ b/sphinx_contributor_listing/__init__.py
@@ -47,8 +47,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
             "Using 'repo_folder' instead.",
             color="yellow",
         )
-        if not html_context.get("repo_folder"):
-            html_context["repo_folder"] = html_context["github_folder"]
+        html_context.setdefault("repo_folder", html_context["github_folder"])
 
     app.connect("html-page-context", add_contributor_context)  # type: ignore[reportUnknownMemberType]
     common.add_css(app, "contributors.css")

--- a/sphinx_contributor_listing/callback.py
+++ b/sphinx_contributor_listing/callback.py
@@ -42,20 +42,20 @@ def add_contributor_context(
         """Get contributors for a specific file."""
         if (
             "display_contributors" not in context
-            or "github_folder" not in context
+            or "repo_folder" not in context
             or "github_url" not in context
         ):
             return []
 
         if context["display_contributors"]:
             filename = f"{pagename}{page_source_suffix}"
-            paths = context["github_folder"][1:] + filename
+            paths = context["repo_folder"][1:] + filename
 
             try:
                 repo = Repo(".")
             except InvalidGitRepositoryError:
                 cwd = str(Path.cwd())
-                ghfolder = context["github_folder"][:-1]
+                ghfolder = context["repo_folder"][:-1]
                 if ghfolder and cwd.endswith(ghfolder):
                     try:
                         repo = Repo(cwd.rpartition(ghfolder)[0])

--- a/tests/integration/example/conf.py
+++ b/tests/integration/example/conf.py
@@ -32,5 +32,5 @@ extensions = [
 
 # Configuration for contributor listing
 display_contributors = False  # Disable for tests since we may not have git history
-github_folder = "/docs/"
+repo_folder = "/docs/"
 github_url = "https://github.com/example/repo"

--- a/tests/integration/test_contributor_integration.py
+++ b/tests/integration/test_contributor_integration.py
@@ -76,7 +76,7 @@ def test_context_functions_work():
     templatename = "test.html"
     context: dict[str, str | bool | dict[str, str] | Callable[[str, str], list]] = {
         "display_contributors": False,
-        "github_folder": "/docs/",
+        "repo_folder": "/docs/",
         "github_url": "https://github.com/example/repo",
     }
     doctree = Mock()

--- a/tests/integration/test_contributor_integration.py
+++ b/tests/integration/test_contributor_integration.py
@@ -51,6 +51,7 @@ def test_extension_setup_function():
 
     app_mock = Mock()
     app_mock.connect = Mock()
+    app_mock.config.html_context = {}
 
     with (
         patch("sphinx_contributor_listing.common.add_css") as mock_add_css,

--- a/tests/unit/test_contributor_listing.py
+++ b/tests/unit/test_contributor_listing.py
@@ -35,6 +35,8 @@ class TestContributorListingSetup:
         """Test that setup returns proper extension metadata."""
         app_mock = Mock(spec=Sphinx)
         app_mock.connect = Mock()
+        app_mock.config = Mock()
+        app_mock.config.html_context = {}
 
         with (
             patch("sphinx_contributor_listing.common.add_css") as mock_add_css,
@@ -53,6 +55,20 @@ class TestContributorListingSetup:
         # Verify CSS and JS are added
         mock_add_css.assert_called_once_with(app_mock, "contributors.css")
         mock_add_js.assert_called_once_with(app_mock, "contributors.js")
+
+    def test_setup_config_vars_legacy(self):
+        """Test legacy config values with fallbacks."""
+        app_mock = Mock(spec=Sphinx)
+        app_mock.connect = Mock()
+        app_mock.config = Mock()
+
+        # Set legacy config values
+        app_mock.config.html_context = {"github_folder": "/docs/"}
+
+        setup(app_mock)
+
+        # Verify that the fallback values are set
+        assert app_mock.config.html_context["repo_folder"] == "/docs/"
 
 
 class TestContributorContextFunctions:
@@ -79,7 +95,7 @@ class TestContributorContextFunctions:
     def test_get_contributors_disabled(self):
         """Test get_contributors_for_file when contributors display is disabled."""
         self.context["display_contributors"] = False
-        self.context["github_folder"] = "/docs/"
+        self.context["repo_folder"] = "/docs/"
         self.context["github_url"] = "https://github.com/example/repo"
 
         add_contributor_context(
@@ -94,7 +110,7 @@ class TestContributorContextFunctions:
         """Test get_contributors_for_file with invalid git repository."""
 
         self.context["display_contributors"] = True
-        self.context["github_folder"] = "/docs/"
+        self.context["repo_folder"] = "/docs/"
         self.context["github_url"] = "https://github.com/example/repo"
 
         # Mock Repo to always raise InvalidGitRepositoryError for any path
@@ -119,7 +135,7 @@ class TestContributorContextFunctions:
     def test_get_contributors_with_commits(self, mock_repo_class):
         """Test get_contributors_for_file with valid commits."""
         self.context["display_contributors"] = True
-        self.context["github_folder"] = "/docs/"
+        self.context["repo_folder"] = "/docs/"
         self.context["github_url"] = "https://github.com/example/repo"
 
         # Mock repository and commits
@@ -160,7 +176,7 @@ class TestContributorContextFunctions:
     def test_get_contributors_with_since_filter(self, mock_repo_class):
         """Test get_contributors_for_file with since filter."""
         self.context["display_contributors"] = True
-        self.context["github_folder"] = "/docs/"
+        self.context["repo_folder"] = "/docs/"
         self.context["github_url"] = "https://github.com/example/repo"
         self.context["display_contributors_since"] = "2024-01-01"
 
@@ -183,7 +199,7 @@ class TestContributorContextFunctions:
     def test_get_contributors_with_co_authors(self, mock_repo_class):
         """Test get_contributors_for_file with co-authors."""
         self.context["display_contributors"] = True
-        self.context["github_folder"] = "/docs/"
+        self.context["repo_folder"] = "/docs/"
         self.context["github_url"] = "https://github.com/example/repo"
 
         # Mock commit with co-authors


### PR DESCRIPTION
canonical-sphinx warns users against using `github_folder`, so we shouldn't depend on it anymore.

If `github_folder` is set, set its value to `repo_folder`.

Used Claude Sonnet for help debugging the tests.

---

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
